### PR TITLE
[Feature] MasterMain 조회 API 전반 구현 (수익/등록자 포함)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,13 @@
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 build/
 /build/
-/generated/
+/src/main/generated
 .gradle
 .idea
 /.env
+/out/
+
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,6 @@ java {
 	}
 }
 
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-}
-
 repositories {
 	mavenCentral()
 }
@@ -33,12 +27,44 @@ dependencies {
 	// postgresql
 	implementation 'org.postgresql:postgresql'
 	runtimeOnly 'org.postgresql:postgresql'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	// QueryDsl
+	implementation "com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	implementation "com.querydsl:querydsl-core"
+	implementation "com.querydsl:querydsl-collections"
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+
+	options.compilerArgs << "-parameters"
+}
+
+
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }

--- a/src/main/java/com/project/fasthrm/FasthrmApplication.java
+++ b/src/main/java/com/project/fasthrm/FasthrmApplication.java
@@ -2,10 +2,10 @@ package com.project.fasthrm;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class FasthrmApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/project/fasthrm/api/MasterMainApi.java
+++ b/src/main/java/com/project/fasthrm/api/MasterMainApi.java
@@ -1,0 +1,25 @@
+package com.project.fasthrm.api;
+
+
+import com.project.fasthrm.dto.response.MasterMainDto;
+import com.project.fasthrm.service.MasterMainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/masters")
+public class MasterMainApi {
+
+    private final MasterMainService masterMainService;
+
+    @GetMapping("main")
+    public ResponseEntity<MasterMainDto> getMasterMainDashboard(@RequestParam Long placeId) {
+        return ResponseEntity.ok(masterMainService.getMasterMainDashboard(placeId));
+    }
+
+}

--- a/src/main/java/com/project/fasthrm/config/DummyDataLoader.java
+++ b/src/main/java/com/project/fasthrm/config/DummyDataLoader.java
@@ -18,7 +18,6 @@ import java.time.LocalDateTime;
 import java.util.*;
 
 @Component
-@Profile("dev")
 @RequiredArgsConstructor
 public class DummyDataLoader implements CommandLineRunner {
 

--- a/src/main/java/com/project/fasthrm/config/DummyDataLoader.java
+++ b/src/main/java/com/project/fasthrm/config/DummyDataLoader.java
@@ -42,15 +42,19 @@ public class DummyDataLoader implements CommandLineRunner {
     @Override
     @Transactional
     public void run(String... args) throws Exception {
+        // ✅ 이미 Place 테이블에 데이터가 존재하면 삽입하지 않음
+        if (placeRepository.count() > 0) {
+            System.out.println("⚠️ Dummy data already exists. Skipping insertion.");
+            return;
+        }
+
         Faker faker = new Faker(new Locale("ko"));
         Random random = new Random();
 
         int batchSize = 1000;
-        int totalCount = 10000;
+        int totalCount = 1000000; // ✅ 데이터 100만 건 생성
+        String[] eduDays = {"월수금", "화목", "토일", "월화수", "수목금","월수","매일"};
 
-        String[] eduDays = {"월수금", "화목", "토일", "월화수", "수목금", "매일"};
-
-        // 1. Place 생성
         List<Place> places = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             Place place = Place.builder()
@@ -61,7 +65,6 @@ public class DummyDataLoader implements CommandLineRunner {
             places.add(place);
         }
 
-        // 2. 사용자, 멤버, 워커, 마스터
         List<Member> members = new ArrayList<>();
         List<Worker> workers = new ArrayList<>();
         for (int i = 0; i < totalCount; i++) {
@@ -109,9 +112,8 @@ public class DummyDataLoader implements CommandLineRunner {
             }
         }
 
-        // 3. Edu 생성
         List<Edu> edus = new ArrayList<>();
-        for (int i = 0; i < 5000; i++) {
+        for (int i = 0; i < 50000; i++) {
             Edu edu = Edu.builder()
                     .place(places.get(random.nextInt(places.size())))
                     .worker(workers.get(random.nextInt(workers.size())))
@@ -123,28 +125,30 @@ public class DummyDataLoader implements CommandLineRunner {
                     .build();
             em.persist(edu);
             edus.add(edu);
+
+            if (i % batchSize == 0 && i > 0) {
+                em.flush();
+                em.clear();
+            }
         }
 
-        // 4. Takes, Attendance, HealthCheck, AcademicCheck, Advisor, Test, WorkTime
-        for (int i = 0; i < 10000; i++) {
+        for (int i = 0; i < 100000; i++) {
             Member member = members.get(random.nextInt(members.size()));
             Worker worker = workers.get(random.nextInt(workers.size()));
             Edu edu = edus.get(random.nextInt(edus.size()));
 
-            Takes takes = Takes.builder()
+            em.persist(Takes.builder()
                     .member(member)
                     .edu(edu)
                     .registeredAt(LocalDate.now().minusDays(random.nextInt(365)))
-                    .build();
-            em.persist(takes);
+                    .build());
 
-            Attendance attendance = Attendance.builder()
+            em.persist(Attendance.builder()
                     .member(member)
                     .attendanceDatetime(LocalDateTime.now().minusDays(random.nextInt(100)))
-                    .build();
-            em.persist(attendance);
+                    .build());
 
-            HealthCheck hc = HealthCheck.builder()
+            em.persist(HealthCheck.builder()
                     .member(member)
                     .hcSex(random.nextBoolean() ? "남" : "여")
                     .hcHeight(150f + random.nextFloat() * 40)
@@ -157,42 +161,37 @@ public class DummyDataLoader implements CommandLineRunner {
                     .hcBodyfatmass(BigDecimal.valueOf(15 + random.nextDouble() * 10))
                     .hcSkeletalmusclemass(BigDecimal.valueOf(25 + random.nextDouble() * 5))
                     .hcReport(faker.lorem().sentence())
-                    .build();
-            em.persist(hc);
+                    .build());
 
-            AcademicCheck ac = AcademicCheck.builder()
+            em.persist(AcademicCheck.builder()
                     .member(member)
                     .acGrade(random.nextInt(6))
                     .acClass("" + (char)(random.nextInt(26) + 'A'))
                     .acSchool(faker.university().name())
                     .acParent(faker.name().fullName())
                     .acDate(LocalDateTime.now().minusDays(random.nextInt(300)))
-                    .build();
-            em.persist(ac);
+                    .build());
 
-            Advisor advisor = Advisor.builder()
+            em.persist(Advisor.builder()
                     .member(member)
                     .worker(worker)
-                    .build();
-            em.persist(advisor);
+                    .build());
 
-            Test test = Test.builder()
-                    .takes(takes)
+            em.persist(Test.builder()
+                    .takes(takesRepository.save(Takes.builder().member(member).edu(edu).registeredAt(LocalDate.now()).build()))
                     .testDay(LocalDate.now().minusDays(random.nextInt(60)))
                     .testResult(faker.letterify("?"))
                     .testName(faker.educator().course())
-                    .build();
-            em.persist(test);
+                    .build());
 
-            WorkTime wt = WorkTime.builder()
+            em.persist(WorkTime.builder()
                     .worker(worker)
                     .worktimeDay(LocalDate.now().minusDays(random.nextInt(60)))
                     .type(random.nextBoolean() ? "정상" : "지각")
                     .time("0" + (8 + random.nextInt(2)) + ":00~18:00")
                     .start(LocalDateTime.now().minusHours(8))
                     .end(LocalDateTime.now())
-                    .build();
-            em.persist(wt);
+                    .build());
 
             if (i % batchSize == 0 && i > 0) {
                 em.flush();
@@ -202,6 +201,6 @@ public class DummyDataLoader implements CommandLineRunner {
 
         em.flush();
         em.clear();
-        System.out.println("✅ Dummy data insertion complete.");
+        System.out.println("✅ 100만건 Dummy 데이터 삽입 완료 (중복 없음)");
     }
 }

--- a/src/main/java/com/project/fasthrm/config/JpaAuditingConfig.java
+++ b/src/main/java/com/project/fasthrm/config/JpaAuditingConfig.java
@@ -1,0 +1,18 @@
+package com.project.fasthrm.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+    @Bean
+    public AuditorAware<String> auditorAware() {
+        return () -> Optional.of("system"); // 시스템 사용자로 설정
+    }
+}

--- a/src/main/java/com/project/fasthrm/config/QuerydslConfig.java
+++ b/src/main/java/com/project/fasthrm/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.project.fasthrm.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/project/fasthrm/domain/AcademicCheck.java
+++ b/src/main/java/com/project/fasthrm/domain/AcademicCheck.java
@@ -2,10 +2,12 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "ac", indexes = {
         @Index(name = "idx_ac_member_date", columnList = "member_id, ac_date")
 })

--- a/src/main/java/com/project/fasthrm/domain/Advisor.java
+++ b/src/main/java/com/project/fasthrm/domain/Advisor.java
@@ -2,8 +2,10 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "advisor")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/project/fasthrm/domain/Attendance.java
+++ b/src/main/java/com/project/fasthrm/domain/Attendance.java
@@ -2,10 +2,12 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "attendance", indexes = {
         @Index(name = "idx_attendance_member_date", columnList = "member_id, attendance_datetime")
 })

--- a/src/main/java/com/project/fasthrm/domain/BaseTime.java
+++ b/src/main/java/com/project/fasthrm/domain/BaseTime.java
@@ -10,9 +10,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-@MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
 @Getter
+@MappedSuperclass
 public class BaseTime {
 
     @CreatedDate

--- a/src/main/java/com/project/fasthrm/domain/Edu.java
+++ b/src/main/java/com/project/fasthrm/domain/Edu.java
@@ -2,12 +2,14 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "edu", indexes = {
         @Index(name = "idx_place_id", columnList = "place_id"),
         @Index(name = "idx_worker_id", columnList = "worker_id")

--- a/src/main/java/com/project/fasthrm/domain/HealthCheck.java
+++ b/src/main/java/com/project/fasthrm/domain/HealthCheck.java
@@ -2,11 +2,13 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "hc", indexes = {
         @Index(name = "idx_member_date", columnList = "member_id, hc_date")
 })

--- a/src/main/java/com/project/fasthrm/domain/Master.java
+++ b/src/main/java/com/project/fasthrm/domain/Master.java
@@ -2,8 +2,10 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "master")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/project/fasthrm/domain/Member.java
+++ b/src/main/java/com/project/fasthrm/domain/Member.java
@@ -2,8 +2,10 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "member")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/project/fasthrm/domain/Place.java
+++ b/src/main/java/com/project/fasthrm/domain/Place.java
@@ -2,8 +2,10 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name="place", indexes = {
         @Index(name="idx_place_name", columnList = "place_name")
 })

--- a/src/main/java/com/project/fasthrm/domain/Takes.java
+++ b/src/main/java/com/project/fasthrm/domain/Takes.java
@@ -2,9 +2,12 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import java.time.LocalDate;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "takes", indexes = {
         @Index(name = "idx_registered_at", columnList = "registered_at")
 })

--- a/src/main/java/com/project/fasthrm/domain/Test.java
+++ b/src/main/java/com/project/fasthrm/domain/Test.java
@@ -2,10 +2,12 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "test", indexes = {
         @Index(name = "idx_test_day", columnList = "test_day")
 })

--- a/src/main/java/com/project/fasthrm/domain/User.java
+++ b/src/main/java/com/project/fasthrm/domain/User.java
@@ -3,8 +3,10 @@ package com.project.fasthrm.domain;
 import com.project.fasthrm.domain.type.UserRole;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "users", indexes = {
         @Index(name = "idx_users_username", columnList = "username"),
         @Index(name = "idx_users_place_role", columnList = "place_id, user_role")

--- a/src/main/java/com/project/fasthrm/domain/WorkTime.java
+++ b/src/main/java/com/project/fasthrm/domain/WorkTime.java
@@ -2,11 +2,13 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "worktime", indexes = {
         @Index(name = "idx_worker_day", columnList = "worker_id, worktime_day")
 })

--- a/src/main/java/com/project/fasthrm/domain/Worker.java
+++ b/src/main/java/com/project/fasthrm/domain/Worker.java
@@ -2,9 +2,11 @@ package com.project.fasthrm.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "worker")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/project/fasthrm/domain/type/UserRole.java
+++ b/src/main/java/com/project/fasthrm/domain/type/UserRole.java
@@ -1,5 +1,14 @@
 package com.project.fasthrm.domain.type;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public enum UserRole {
-    MASTER, WORKER, MEMBER
+    MASTER("ROLE_MASTER", "관리자"),
+    WORKER("ROLE_WORKER", "직원"),
+    MEMBER("ROLE_MEMBER", "회원");
+
+    @Getter private final String roleName;
+    @Getter private final String description;
 }

--- a/src/main/java/com/project/fasthrm/dto/response/EduRevenueDto.java
+++ b/src/main/java/com/project/fasthrm/dto/response/EduRevenueDto.java
@@ -1,0 +1,38 @@
+package com.project.fasthrm.dto.response;
+
+import lombok.*;
+import org.springframework.data.annotation.PersistenceConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@EqualsAndHashCode
+public class EduRevenueDto {
+    // 교육별 수익
+    private Long eduId;
+    private String eduName;       // 교육명
+    private Long studentCount;    // 수강생 수
+    private Long unitPrice;       // 1인당 수강료
+    private Long revenue;         // 총 수익 (계산값)
+
+
+    public EduRevenueDto(Long eduId, String eduName, Long unitPrice, Long studentCount) {
+        this.eduId = eduId;
+        this.eduName = eduName;
+        this.unitPrice = unitPrice;
+        this.studentCount = studentCount;
+        this.revenue = unitPrice * studentCount;
+    }
+
+    public EduRevenueDto(Long eduId, String eduName, BigDecimal unitPrice, Long studentCount) {
+        this.eduId = eduId;
+        this.eduName = eduName;
+        this.unitPrice = unitPrice != null ? unitPrice.longValue() : 0L;
+        this.studentCount = studentCount;
+        this.revenue = this.unitPrice * studentCount;
+    }
+
+}

--- a/src/main/java/com/project/fasthrm/dto/response/MasterMainDto.java
+++ b/src/main/java/com/project/fasthrm/dto/response/MasterMainDto.java
@@ -1,0 +1,17 @@
+package com.project.fasthrm.dto.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MasterMainDto {
+
+    private List<EduRevenueDto> eduRevenueList; // 교육별 수익
+    private List<MonthlyEduRevenueDto> monthlyEduRevenueList; // 월별 수익
+    private List<MonthlyRegistrationDto> monthlyRegistrationList; // 월별 등록자 수
+
+}

--- a/src/main/java/com/project/fasthrm/dto/response/MonthlyEduRevenueDto.java
+++ b/src/main/java/com/project/fasthrm/dto/response/MonthlyEduRevenueDto.java
@@ -1,0 +1,17 @@
+package com.project.fasthrm.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MonthlyEduRevenueDto {
+    // 월별 수익
+    private String month;
+    private Long totalRevenue;   // 월별 총 수익
+
+}

--- a/src/main/java/com/project/fasthrm/dto/response/MonthlyRegistrationDto.java
+++ b/src/main/java/com/project/fasthrm/dto/response/MonthlyRegistrationDto.java
@@ -1,0 +1,16 @@
+package com.project.fasthrm.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MonthlyRegistrationDto {
+    // 월별 등록자 수
+    private String month;             // 월
+    private Long totalRegistrations; // 등록자 수
+}

--- a/src/main/java/com/project/fasthrm/repository/MasterMainQueryRepository.java
+++ b/src/main/java/com/project/fasthrm/repository/MasterMainQueryRepository.java
@@ -1,0 +1,14 @@
+package com.project.fasthrm.repository;
+
+import com.project.fasthrm.dto.response.EduRevenueDto;
+import com.project.fasthrm.dto.response.MonthlyEduRevenueDto;
+import com.project.fasthrm.dto.response.MonthlyRegistrationDto;
+
+import java.util.List;
+
+public interface MasterMainQueryRepository {
+    List<EduRevenueDto> getEduRevenue(Long placeId);
+    List<MonthlyEduRevenueDto> getMonthlyEduRevenue(Long placeId);
+    List<MonthlyRegistrationDto> getMonthlyRegistration(Long placeId);
+
+}

--- a/src/main/java/com/project/fasthrm/repository/MasterMainQueryRepositoryImpl.java
+++ b/src/main/java/com/project/fasthrm/repository/MasterMainQueryRepositoryImpl.java
@@ -1,0 +1,97 @@
+package com.project.fasthrm.repository;
+
+import com.project.fasthrm.domain.QEdu;
+import com.project.fasthrm.domain.QMember;
+import com.project.fasthrm.domain.QTakes;
+import com.project.fasthrm.domain.QUser;
+import com.project.fasthrm.domain.type.UserRole;
+import com.project.fasthrm.dto.response.EduRevenueDto;
+import com.project.fasthrm.dto.response.MonthlyEduRevenueDto;
+import com.project.fasthrm.dto.response.MonthlyRegistrationDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MasterMainQueryRepositoryImpl implements MasterMainQueryRepository{
+
+    private final JPAQueryFactory queryFactory;
+
+    // 교육별 총 누적수익
+    @Override
+    public List<EduRevenueDto> getEduRevenue(Long placeId) {
+        QTakes t = QTakes.takes;
+        QEdu e = QEdu.edu;
+        QMember m = QMember.member;
+        QUser u = QUser.user;
+
+
+        return queryFactory
+                .select(Projections.constructor(
+                        EduRevenueDto.class,
+                        e.id,
+                        e.eduName,
+                        e.eduTuition,
+                        t.count()
+                ))
+                .from(t)
+                .join(t.member.user, u)
+                .join(t.edu, e)
+                .where(
+                        u.place.id.eq(placeId),
+                        u.userRole.eq(UserRole.MEMBER)
+                )
+                .groupBy(e.id, e.eduName, e.eduTuition)
+                .fetch();
+
+
+    }
+
+    // 월별 총수익
+    @Override
+    public List<MonthlyEduRevenueDto> getMonthlyEduRevenue(Long placeId) {
+        QTakes t = QTakes.takes;
+        QEdu e = QEdu.edu;
+        QUser u = QUser.user;
+
+        return queryFactory
+                .select(Projections.constructor(
+                        MonthlyEduRevenueDto.class,
+                        Expressions.stringTemplate("TO_CHAR({0}, 'YYYY-MM')", t.registeredAt),
+                        Expressions.stringTemplate("SUM({0})", e.eduTuition)
+                                .castToNum(Long.class)
+                ))
+                .from(t)
+                .join(t.edu, e)
+                .join(t.member.user, u)
+                .where(u.place.id.eq(placeId), u.userRole.eq(UserRole.MEMBER))
+                .groupBy(Expressions.stringTemplate("TO_CHAR({0}, 'YYYY-MM')", t.registeredAt))
+                .fetch();
+    }
+
+    // 월별 등록자 수
+    @Override
+    public List<MonthlyRegistrationDto> getMonthlyRegistration(Long placeId) {
+        QTakes t = QTakes.takes;
+        QUser u = QUser.user;
+
+        return queryFactory
+                .select(Projections.constructor(
+                        MonthlyRegistrationDto.class,
+                        Expressions.stringTemplate("TO_CHAR({0}, 'YYYY-MM')", t.registeredAt),
+                        t.count()
+                ))
+                .from(t)
+                .join(t.member.user, u)
+                .where(u.place.id.eq(placeId), u.userRole.eq(UserRole.MEMBER))
+                .groupBy(Expressions.stringTemplate("TO_CHAR({0}, 'YYYY-MM')", t.registeredAt))
+                .fetch();
+
+    }
+
+}

--- a/src/main/java/com/project/fasthrm/repository/MasterRepository.java
+++ b/src/main/java/com/project/fasthrm/repository/MasterRepository.java
@@ -4,6 +4,9 @@ import com.project.fasthrm.domain.Master;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MasterRepository extends JpaRepository<Master, Long> {
+
 }

--- a/src/main/java/com/project/fasthrm/service/MasterMainService.java
+++ b/src/main/java/com/project/fasthrm/service/MasterMainService.java
@@ -1,0 +1,9 @@
+package com.project.fasthrm.service;
+
+import com.project.fasthrm.dto.response.MasterMainDto;
+
+
+public interface MasterMainService {
+
+    MasterMainDto getMasterMainDashboard(Long placeId);
+}

--- a/src/main/java/com/project/fasthrm/service/impl/MasterMainServiceImpl.java
+++ b/src/main/java/com/project/fasthrm/service/impl/MasterMainServiceImpl.java
@@ -1,0 +1,29 @@
+package com.project.fasthrm.service.impl;
+
+import com.project.fasthrm.dto.response.MasterMainDto;
+
+import com.project.fasthrm.repository.MasterMainQueryRepository;
+import com.project.fasthrm.service.MasterMainService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MasterMainServiceImpl implements MasterMainService {
+
+    private final MasterMainQueryRepository repository;
+
+    @Override
+    public MasterMainDto getMasterMainDashboard(Long placeId) {
+        return MasterMainDto.builder()
+                .eduRevenueList(repository.getEduRevenue(placeId))
+                .monthlyEduRevenueList(repository.getMonthlyEduRevenue(placeId))
+                .monthlyRegistrationList(repository.getMonthlyRegistration(placeId))
+                .build();
+    }
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,3 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
-
-  profiles:
-    active: dev

--- a/src/test/java/com/project/fasthrm/MasterMainQueryTest.java
+++ b/src/test/java/com/project/fasthrm/MasterMainQueryTest.java
@@ -1,0 +1,251 @@
+package com.project.fasthrm;
+
+import com.project.fasthrm.config.QuerydslConfig;
+import com.project.fasthrm.domain.QEdu;
+import com.project.fasthrm.domain.QMember;
+import com.project.fasthrm.domain.QTakes;
+import com.project.fasthrm.domain.QUser;
+import com.project.fasthrm.domain.type.UserRole;
+import com.project.fasthrm.dto.response.EduRevenueDto;
+import com.project.fasthrm.service.MasterMainService;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.*;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Import(QuerydslConfig.class)
+@MockitoBean(types = {MasterMainService.class})
+public class MasterMainQueryTest {
+
+    @Autowired private EntityManager entityManager;
+    @Autowired private JPAQueryFactory queryFactory;
+
+    private static final int REPEAT_COUNT = 500;
+    private static final Long PLACE_ID = 1L;
+
+    @Test
+    void compareQueryPerformance() {
+        Runtime runtime = Runtime.getRuntime();
+
+        List<EduRevenueDto> nativeResults = runOriginalNativeSql();
+        List<EduRevenueDto> improvedResults = runImprovedNativeSql();
+        List<EduRevenueDto> jpqlResults = runJPQL();
+        List<EduRevenueDto> querydslResults = runQueryDSL();
+
+        Comparator<EduRevenueDto> comparator = Comparator
+                .comparing(EduRevenueDto::getEduId)
+                .thenComparing(EduRevenueDto::getEduName);
+
+        nativeResults.sort(comparator);
+        improvedResults.sort(comparator);
+        jpqlResults.sort(comparator);
+        querydslResults.sort(comparator);
+
+        assertEquals(nativeResults, improvedResults, "개선된 Native SQL 결과가 다릅니다.");
+        assertEquals(nativeResults, jpqlResults, "JPQL 결과가 다릅니다.");
+        assertEquals(nativeResults, querydslResults, "QueryDSL 결과가 다릅니다.");
+
+        // 성능 측정 (선택적)
+        long nativeStart = System.currentTimeMillis();
+        for (int i = 0; i < REPEAT_COUNT; i++) runOriginalNativeSql();
+        long nativeEnd = System.currentTimeMillis();
+
+        long improvedStart = System.currentTimeMillis();
+        for (int i = 0; i < REPEAT_COUNT; i++) runImprovedNativeSql();
+        long improvedEnd = System.currentTimeMillis();
+
+        long jpqlStart = System.currentTimeMillis();
+        for (int i = 0; i < REPEAT_COUNT; i++) runJPQL();
+        long jpqlEnd = System.currentTimeMillis();
+
+        long querydslStart = System.currentTimeMillis();
+        for (int i = 0; i < REPEAT_COUNT; i++) runQueryDSL();
+        long querydslEnd = System.currentTimeMillis();
+
+        System.out.println("\n=== 성능 측정 결과 ===");
+        System.out.println("1. 기존 Native SQL     : " + ((nativeEnd - nativeStart) / REPEAT_COUNT) + "ms");
+        System.out.println("2. 개선된 Native SQL   : " + ((improvedEnd - improvedStart) / REPEAT_COUNT) + "ms");
+        System.out.println("3. JPQL                : " + ((jpqlEnd - jpqlStart) / REPEAT_COUNT) + "ms");
+        System.out.println("4. QueryDSL            : " + ((querydslEnd - querydslStart) / REPEAT_COUNT) + "ms");
+    }
+
+    private List<EduRevenueDto> runOriginalNativeSql() {
+        String sql = """
+            SELECT e.edu_id, e.edu_name, e.edu_tuition, COUNT(t.takes_id)
+            FROM takes t
+            JOIN edu e ON t.edu_id = e.edu_id
+            JOIN member m ON t.member_id = m.member_id
+            JOIN users u ON m.user_id = u.user_id
+            WHERE u.place_id = :placeId AND u.user_role = 'MEMBER'
+            GROUP BY e.edu_id, e.edu_name, e.edu_tuition
+        """;
+
+        List<Object[]> results = entityManager.createNativeQuery(sql)
+                .setParameter("placeId", PLACE_ID)
+                .getResultList();
+
+        List<EduRevenueDto> dtoList = new ArrayList<>();
+        for (Object[] row : results) {
+            Long eduId = ((Number) row[0]).longValue();
+            String eduName = (String) row[1];
+            Long unitPrice = ((Number) row[2]).longValue();
+            Long studentCount = ((Number) row[3]).longValue();
+            dtoList.add(new EduRevenueDto(eduId, eduName, unitPrice, studentCount));
+        }
+
+        return dtoList;
+    }
+
+    private List<EduRevenueDto> runImprovedNativeSql() {
+        String sql = """
+            SELECT e.edu_id, e.edu_name, e.edu_tuition, COUNT(*)
+            FROM takes t
+            JOIN edu e ON t.edu_id = e.edu_id
+            WHERE EXISTS (
+                SELECT 1 FROM member m
+                JOIN users u ON m.user_id = u.user_id
+                WHERE m.member_id = t.member_id
+                  AND u.place_id = :placeId
+                  AND u.user_role = 'MEMBER'
+            )
+            GROUP BY e.edu_id, e.edu_name, e.edu_tuition
+        """;
+
+        List<Object[]> results = entityManager.createNativeQuery(sql)
+                .setParameter("placeId", PLACE_ID)
+                .getResultList();
+
+        List<EduRevenueDto> dtoList = new ArrayList<>();
+        for (Object[] row : results) {
+            Long eduId = ((Number) row[0]).longValue();
+            String eduName = (String) row[1];
+            Long unitPrice = ((Number) row[2]).longValue();
+            Long studentCount = ((Number) row[3]).longValue();
+            dtoList.add(new EduRevenueDto(eduId, eduName, unitPrice, studentCount));
+        }
+
+        return dtoList;
+    }
+
+    private List<EduRevenueDto> runJPQL() {
+        String jpql = """
+            SELECT new com.project.fasthrm.dto.response.EduRevenueDto(
+                e.id, e.eduName, e.eduTuition, COUNT(t)
+            )
+            FROM Takes t
+            JOIN t.edu e
+            JOIN t.member m
+            JOIN m.user u
+            WHERE u.place.id = :placeId AND u.userRole = com.project.fasthrm.domain.type.UserRole.MEMBER
+            GROUP BY e.id, e.eduName, e.eduTuition
+        """;
+
+        return entityManager.createQuery(jpql, EduRevenueDto.class)
+                .setParameter("placeId", PLACE_ID)
+                .getResultList();
+    }
+
+    private List<EduRevenueDto> runQueryDSL() {
+        QTakes t = QTakes.takes;
+        QEdu e = QEdu.edu;
+        QMember m = QMember.member;
+        QUser u = QUser.user;
+
+        return queryFactory.select(Projections.constructor(
+                        EduRevenueDto.class,
+                        e.id,
+                        e.eduName,
+                        e.eduTuition,
+                        t.count()
+                ))
+                .from(t)
+                .join(t.edu, e)
+                .join(t.member, m)
+                .join(m.user, u)
+                .where(
+                        u.place.id.eq(PLACE_ID)
+                                .and(u.userRole.eq(UserRole.MEMBER))
+                )
+                .groupBy(e.id, e.eduName, e.eduTuition)
+                .fetch();
+    }
+
+
+    @Test
+    void compareJoinDepthInQueryDSL() {
+        QTakes t = QTakes.takes;
+        QMember m = QMember.member;
+        QUser u = QUser.user;
+        QEdu e = QEdu.edu;
+
+        // 1. 3단계 JOIN 방식
+        long start1 = System.nanoTime();
+        List<EduRevenueDto> threeJoin = queryFactory
+                .select(Projections.constructor(
+                        EduRevenueDto.class,
+                        e.id,
+                        e.eduName,
+                        e.eduTuition,
+                        t.id.count()
+                ))
+                .from(t)
+                .join(t.member, m)
+                .join(m.user, u)
+                .join(t.edu, e)
+                .where(
+                        u.place.id.eq(PLACE_ID),
+                        u.userRole.eq(UserRole.MEMBER)
+                )
+                .groupBy(e.id, e.eduName, e.eduTuition)
+                .fetch();
+        long end1 = System.nanoTime();
+
+        // 2. 단축 JOIN (중첩 join 한 줄 처리)
+        long start2 = System.nanoTime();
+        List<EduRevenueDto> nestedJoin = queryFactory
+                .select(Projections.constructor(
+                        EduRevenueDto.class,
+                        e.id,
+                        e.eduName,
+                        e.eduTuition,
+                        t.id.count()
+                ))
+                .from(t)
+                .join(t.member.user, u)
+                .join(t.edu, e)
+                .where(
+                        u.place.id.eq(PLACE_ID),
+                        u.userRole.eq(UserRole.MEMBER)
+                )
+                .groupBy(e.id, e.eduName, e.eduTuition)
+                .fetch();
+        long end2 = System.nanoTime();
+
+        // 3. 결과 비교
+        Comparator<EduRevenueDto> comparator = Comparator
+                .comparing(EduRevenueDto::getEduId)
+                .thenComparing(EduRevenueDto::getEduName);
+
+        threeJoin.sort(comparator);
+        nestedJoin.sort(comparator);
+
+        assertThat(threeJoin).usingRecursiveComparison().isEqualTo(nestedJoin);
+
+        // 4. 성능 출력
+        System.out.printf("3단계 JOIN: %.3f ms\n", (end1 - start1) / 1_000_000.0);
+        System.out.printf("중첩 JOIN: %.3f ms\n", (end2 - start2) / 1_000_000.0);
+    }
+
+}

--- a/src/test/java/com/project/fasthrm/api/MasterMainApiTest.java
+++ b/src/test/java/com/project/fasthrm/api/MasterMainApiTest.java
@@ -1,0 +1,71 @@
+package com.project.fasthrm.api;
+
+
+import com.project.fasthrm.dto.response.EduRevenueDto;
+import com.project.fasthrm.dto.response.MasterMainDto;
+import com.project.fasthrm.dto.response.MonthlyEduRevenueDto;
+import com.project.fasthrm.dto.response.MonthlyRegistrationDto;
+import com.project.fasthrm.service.MasterMainService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(controllers = MasterMainApi.class)
+@DisplayName("API: MasterMain")
+class MasterMainApiTest {
+
+    @Autowired private MockMvc mvc;
+
+    @MockitoBean private MasterMainService masterMainService;
+
+    @Test
+    @DisplayName("장소 ID가 주어졌을 때 대시보드 데이터 반환")
+    void shouldReturnDashboardData() throws Exception {
+        // Given
+        Long placeId = 1L;
+        MasterMainDto mockDto = MasterMainDto.builder()
+                .eduRevenueList(List.of(
+                        EduRevenueDto.builder()
+                                .eduName("Java 기초")
+                                .studentCount(10L)
+                                .unitPrice(50000L)
+                                .revenue(500000L)
+                                .build()
+                ))
+                .monthlyEduRevenueList(List.of(
+                        MonthlyEduRevenueDto.builder()
+                                .month("1월")
+                                .totalRevenue(500000L)
+                                .build()
+                ))
+                .monthlyRegistrationList(List.of(
+                        MonthlyRegistrationDto.builder()
+                                .month("1월")
+                                .totalRegistrations(10L)
+                                .build()
+                ))
+                .build();
+
+        given(masterMainService.getMasterMainDashboard(placeId)).willReturn(mockDto);
+
+        // When & Then
+        mvc.perform(get("/api/masters/main").param("placeId", "1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eduRevenueList[0].eduName").value("Java 기초"))
+                .andExpect(jsonPath("$.monthlyEduRevenueList[0].month").value("1월"))
+                .andExpect(jsonPath("$.monthlyRegistrationList[0].month").value("1월"));
+    }
+}


### PR DESCRIPTION
- /api/masters/main 연동
- MasterMain 대시보드에 필요한 데이터 응답 구조 설계 및 적용
- 교육별 누적 수익, 월별 총 수익, 월별 등록자 수 통계 데이터 제공
- DTO, QueryDSL, Service, Controller 전반 구현 완료

This is #3