### PR TITLE
[Feature] WorkerMain조회 API 구현(worker 정보)

### DIFF
--- a/src/main/java/com/project/fasthrm/api/WorkerMainApi.java
+++ b/src/main/java/com/project/fasthrm/api/WorkerMainApi.java
@@ -1,0 +1,24 @@
+package com.project.fasthrm.api;
+
+import com.project.fasthrm.dto.response.WorkerMainDto;
+import com.project.fasthrm.service.WorkerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/worker")
+public class WorkerMainApi {
+
+    private final WorkerService workerService;
+
+    @GetMapping("/main")
+    public List<WorkerMainDto> findWorkers(@RequestParam Long placeId) {
+        return workerService.findWorkerByPlaceId(placeId);
+    }
+}

--- a/src/main/java/com/project/fasthrm/dto/response/EduRevenueDto.java
+++ b/src/main/java/com/project/fasthrm/dto/response/EduRevenueDto.java
@@ -1,15 +1,13 @@
 package com.project.fasthrm.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
 import org.springframework.data.annotation.PersistenceConstructor;
 
 import java.math.BigDecimal;
 
-@Data
-@AllArgsConstructor
+@Getter
 @NoArgsConstructor
-@Builder
-@EqualsAndHashCode
 public class EduRevenueDto {
     // 교육별 수익
     private Long eduId;
@@ -19,6 +17,7 @@ public class EduRevenueDto {
     private Long revenue;         // 총 수익 (계산값)
 
 
+    @QueryProjection
     public EduRevenueDto(Long eduId, String eduName, Long unitPrice, Long studentCount) {
         this.eduId = eduId;
         this.eduName = eduName;

--- a/src/main/java/com/project/fasthrm/dto/response/MonthlyEduRevenueDto.java
+++ b/src/main/java/com/project/fasthrm/dto/response/MonthlyEduRevenueDto.java
@@ -1,17 +1,20 @@
 package com.project.fasthrm.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.*;
 
-@Data
-@AllArgsConstructor
+@Getter
 @NoArgsConstructor
-@Builder
 public class MonthlyEduRevenueDto {
     // 월별 수익
     private String month;
     private Long totalRevenue;   // 월별 총 수익
+
+
+    @QueryProjection
+    public MonthlyEduRevenueDto(String month, Long totalRevenue) {
+        this.month = month;
+        this.totalRevenue = totalRevenue;
+    }
 
 }

--- a/src/main/java/com/project/fasthrm/dto/response/MonthlyRegistrationDto.java
+++ b/src/main/java/com/project/fasthrm/dto/response/MonthlyRegistrationDto.java
@@ -1,16 +1,18 @@
 package com.project.fasthrm.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.*;
 
-@Data
-@AllArgsConstructor
+@Getter
 @NoArgsConstructor
-@Builder
 public class MonthlyRegistrationDto {
     // 월별 등록자 수
     private String month;             // 월
     private Long totalRegistrations; // 등록자 수
+
+    @QueryProjection
+    public MonthlyRegistrationDto(String month, Long totalRegistrations) {
+        this.month = month;
+        this.totalRegistrations = totalRegistrations;
+    }
 }

--- a/src/main/java/com/project/fasthrm/dto/response/WorkerMainDto.java
+++ b/src/main/java/com/project/fasthrm/dto/response/WorkerMainDto.java
@@ -1,0 +1,31 @@
+package com.project.fasthrm.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WorkerMainDto {
+
+    private Long userId;
+    private String username;
+    private String password;
+    private String userRealName;
+    private String userAddress;
+    private String userPhoneNumber;
+    private Integer workerSalary;
+
+    @QueryProjection
+    public WorkerMainDto(Long userId, String username, String password, String userRealName,
+                         String userAddress, String userPhoneNumber, Integer workerSalary) {
+        this.userId = userId;
+        this.username = username;
+        this.password = password;
+        this.userRealName = userRealName;
+        this.userAddress = userAddress;
+        this.userPhoneNumber = userPhoneNumber;
+        this.workerSalary = workerSalary;
+    }
+}

--- a/src/main/java/com/project/fasthrm/repository/query/MasterMainQueryRepository.java
+++ b/src/main/java/com/project/fasthrm/repository/query/MasterMainQueryRepository.java
@@ -1,4 +1,4 @@
-package com.project.fasthrm.repository;
+package com.project.fasthrm.repository.query;
 
 import com.project.fasthrm.dto.response.EduRevenueDto;
 import com.project.fasthrm.dto.response.MonthlyEduRevenueDto;

--- a/src/main/java/com/project/fasthrm/repository/query/MasterMainQueryRepositoryImpl.java
+++ b/src/main/java/com/project/fasthrm/repository/query/MasterMainQueryRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.project.fasthrm.repository;
+package com.project.fasthrm.repository.query;
 
 import com.project.fasthrm.domain.QEdu;
 import com.project.fasthrm.domain.QMember;

--- a/src/main/java/com/project/fasthrm/repository/query/WorkerQueryRepository.java
+++ b/src/main/java/com/project/fasthrm/repository/query/WorkerQueryRepository.java
@@ -1,0 +1,11 @@
+package com.project.fasthrm.repository.query;
+
+import com.project.fasthrm.dto.response.WorkerMainDto;
+
+import java.util.List;
+
+public interface WorkerQueryRepository {
+
+    List<WorkerMainDto> findWorkerByPlaceId(Long placeId);
+
+}

--- a/src/main/java/com/project/fasthrm/repository/query/WorkerQueryRepositoryImpl.java
+++ b/src/main/java/com/project/fasthrm/repository/query/WorkerQueryRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.project.fasthrm.repository.query;
+
+import com.project.fasthrm.domain.QUser;
+import com.project.fasthrm.domain.QWorker;
+import com.project.fasthrm.dto.response.QWorkerMainDto;
+import com.project.fasthrm.dto.response.WorkerMainDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class WorkerQueryRepositoryImpl implements WorkerQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<WorkerMainDto> findWorkerByPlaceId(Long placeId) {
+        QWorker worker = QWorker.worker;
+        QUser user = QUser.user;
+
+        return queryFactory
+                .select(new QWorkerMainDto(
+                        user.id,
+                        user.username,
+                        user.password,
+                        user.userRealName,
+                        user.userAddress,
+                        user.userPhoneNumber,
+                        worker.workerSalary
+                ))
+                .from(worker)
+                .join(worker.user, user)
+                .where(user.place.id.eq(placeId))
+                .fetch();
+    }
+}

--- a/src/main/java/com/project/fasthrm/service/WorkerService.java
+++ b/src/main/java/com/project/fasthrm/service/WorkerService.java
@@ -1,0 +1,12 @@
+package com.project.fasthrm.service;
+
+
+import com.project.fasthrm.dto.response.WorkerMainDto;
+
+import java.util.List;
+
+public interface WorkerService {
+
+    List<WorkerMainDto> findWorkerByPlaceId(Long placeId);
+
+}

--- a/src/main/java/com/project/fasthrm/service/impl/MasterMainServiceImpl.java
+++ b/src/main/java/com/project/fasthrm/service/impl/MasterMainServiceImpl.java
@@ -2,7 +2,7 @@ package com.project.fasthrm.service.impl;
 
 import com.project.fasthrm.dto.response.MasterMainDto;
 
-import com.project.fasthrm.repository.MasterMainQueryRepository;
+import com.project.fasthrm.repository.query.MasterMainQueryRepository;
 import com.project.fasthrm.service.MasterMainService;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/project/fasthrm/service/impl/WorkerServiceImpl.java
+++ b/src/main/java/com/project/fasthrm/service/impl/WorkerServiceImpl.java
@@ -1,0 +1,23 @@
+package com.project.fasthrm.service.impl;
+
+import com.project.fasthrm.dto.response.WorkerMainDto;
+import com.project.fasthrm.repository.query.WorkerQueryRepository;
+import com.project.fasthrm.service.WorkerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WorkerServiceImpl implements WorkerService {
+
+    private final WorkerQueryRepository workerQueryRepository;
+
+    @Override
+    public List<WorkerMainDto> findWorkerByPlaceId(Long placeId) {
+
+        return workerQueryRepository.findWorkerByPlaceId(placeId);
+    }
+
+}

--- a/src/test/java/com/project/fasthrm/api/MasterMainApiTest.java
+++ b/src/test/java/com/project/fasthrm/api/MasterMainApiTest.java
@@ -35,27 +35,30 @@ class MasterMainApiTest {
     void shouldReturnDashboardData() throws Exception {
         // Given
         Long placeId = 1L;
+
+        // 각 DTO를 new 생성자 기반으로 생성
+        EduRevenueDto eduRevenueDto = new EduRevenueDto(
+                1L,              // eduId
+                "Java 기초",      // eduName
+                50000L,          // unitPrice
+                10L              // studentCount
+                // revenue는 unitPrice * studentCount로 자동 계산됨
+        );
+
+        MonthlyEduRevenueDto monthlyEduRevenueDto = new MonthlyEduRevenueDto(
+                "1월",
+                500000L
+        );
+
+        MonthlyRegistrationDto monthlyRegistrationDto = new MonthlyRegistrationDto(
+                "1월",
+                10L
+        );
+
         MasterMainDto mockDto = MasterMainDto.builder()
-                .eduRevenueList(List.of(
-                        EduRevenueDto.builder()
-                                .eduName("Java 기초")
-                                .studentCount(10L)
-                                .unitPrice(50000L)
-                                .revenue(500000L)
-                                .build()
-                ))
-                .monthlyEduRevenueList(List.of(
-                        MonthlyEduRevenueDto.builder()
-                                .month("1월")
-                                .totalRevenue(500000L)
-                                .build()
-                ))
-                .monthlyRegistrationList(List.of(
-                        MonthlyRegistrationDto.builder()
-                                .month("1월")
-                                .totalRegistrations(10L)
-                                .build()
-                ))
+                .eduRevenueList(List.of(eduRevenueDto))
+                .monthlyEduRevenueList(List.of(monthlyEduRevenueDto))
+                .monthlyRegistrationList(List.of(monthlyRegistrationDto))
                 .build();
 
         given(masterMainService.getMasterMainDashboard(placeId)).willReturn(mockDto);

--- a/src/test/java/com/project/fasthrm/api/WorkerMainApiTest.java
+++ b/src/test/java/com/project/fasthrm/api/WorkerMainApiTest.java
@@ -1,0 +1,61 @@
+package com.project.fasthrm.api;
+
+import com.project.fasthrm.dto.response.WorkerMainDto;
+import com.project.fasthrm.service.WorkerService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("API: WorkerMain")
+@WebMvcTest(WorkerMainApi.class)
+public class WorkerMainApiTest {
+
+    @Autowired private MockMvc mvc;
+
+    @MockitoBean private WorkerService workerService;
+
+
+    @Test
+    @DisplayName("WorkerMain - placeId에 따라 worker 리스트 정상 반환 ")
+    void givenPlaceId_whenRequestingWorkerMainApi_thenReturnsWorkerView() throws Exception {
+        // Given
+        List<WorkerMainDto> mockWorkers = List.of(
+                new WorkerMainDto(1L, "worker1","password", "Worker One", "서울시", "01012345678", 3000000),
+                new WorkerMainDto(2L, "worker2","password", "Worker Two", "경기도", "01078941234", 4000000)
+        );
+        Mockito.when(workerService.findWorkerByPlaceId(anyLong())).thenReturn(mockWorkers);
+
+        // When & Then
+        mvc.perform(get("/api/worker/main").param("placeId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2)) // 리스트 크기 2개 확인
+                .andExpect(jsonPath("$[0].username").value("worker1"))
+                .andExpect(jsonPath("$[0].password").value("password"))
+                .andExpect(jsonPath("$[0].userRealName").value("Worker One"))
+                .andExpect(jsonPath("$[0].userAddress").value("서울시"))
+                .andExpect(jsonPath("$[0].userPhoneNumber").value("01012345678"))
+                .andExpect(jsonPath("$[0].workerSalary").value(3000000))
+
+                .andExpect(jsonPath("$[1].username").value("worker2"))
+                .andExpect(jsonPath("$[1].password").value("password"))
+                .andExpect(jsonPath("$[1].userRealName").value("Worker Two"))
+                .andExpect(jsonPath("$[1].userAddress").value("경기도"))
+                .andExpect(jsonPath("$[1].userPhoneNumber").value("01078941234"))
+                .andExpect(jsonPath("$[1].workerSalary").value(4000000));
+
+
+
+
+    }
+}


### PR DESCRIPTION
- mastermain 에서 @QueryProjection 로 수정하기 위해 dto, test 수정
- repository에 있는 query부분을 query 파일로 따로 저장
- /api/worker/main 연동
- WorkerMain 대시보드에 필요항 데이터 응답 구조 설계 및 적용
- DTO, QueryDSL, Service, Controller 전반 구현 완료

 [참고] mastermain부분을 mastermain 브랜치에 했어야 했지만  혼자하는 프로젝트이니까 그냥 넘어감

This is #4 